### PR TITLE
Fix game-over screen to finish horizontal

### DIFF
--- a/src/Game.qml
+++ b/src/Game.qml
@@ -569,7 +569,7 @@ Item {
             origin.x: width/2
             origin.y: height/2
             angle: gameOver.angle
-            Behavior on angle { NumberAnimation { easing.type: Easing.InCubic; duration: 600 } }
+            Behavior on angle { NumberAnimation { to: -405; easing.type: Easing.InCubic; duration: 600 } }
         }
 
         Behavior on opacity { NumberAnimation { duration: 200 } }


### PR DESCRIPTION
The game over screen was ending up tilted 45 degrees with the rest of
the game; this fixes that to have the game over screen spin into place
but finish oriented horizontally.