### PR TITLE
Save state when the game is reset

### DIFF
--- a/src/Game.qml
+++ b/src/Game.qml
@@ -279,6 +279,7 @@ Item {
             }
             randCell()
             randCell()
+            synchronize()
         }
 
         Timer {


### PR DESCRIPTION
Previously the game state would only be saved after the user has made a move.
The state was never saved when the game was reset (user presses "Try Again").


This fixes https://github.com/AsteroidOS/asteroid-diamonds/issues/3