### PR TITLE
Game: Fix grid size and score position when screen is not square or round.

### DIFF
--- a/src/Game.qml
+++ b/src/Game.qml
@@ -2,6 +2,7 @@ import QtQuick 2.9
 import Nemo.Configuration 1.0
 import org.nemomobile.lipstick 0.1
 import org.asteroid.utils 1.0
+import org.asteroid.controls 1.0
 
 Item {
     id: main
@@ -300,7 +301,9 @@ Item {
 
         Item {
             id: scoreBoard
-            anchors.fill: parent
+            width: Dims.l(100)
+            height: Dims.l(100)
+            anchors.centerIn: parent
 
             opacity: 0.7
 
@@ -375,21 +378,12 @@ Item {
 
         Item {
             id: board
-            property int fieldWidth: Math.floor(Math.sqrt(Math.pow(parent.width, 2)/2))
-            property int fieldHeight: Math.floor(Math.sqrt(Math.pow(parent.height, 2)/2))
-            property int fieldMarginWidth: (parent.width-fieldWidth)/2
-            property int fieldMarginHeight: (parent.height-fieldHeight)/2
+            // As the field is rotated by 45°, make sure that the diagonal of the field matches the minimum length.
+            property int fieldSize: Math.floor(Math.sqrt(Math.pow(Dims.l(100), 2)/2))
 
-            anchors {
-                right: parent.right;
-                left: parent.left;
-                bottom: parent.bottom;
-                top: parent.top;
-                leftMargin: fieldMarginWidth;
-                rightMargin: fieldMarginWidth;
-                topMargin: fieldMarginHeight;
-                bottomMargin: fieldMarginHeight;
-            }
+            width: fieldSize
+            height: fieldSize
+            anchors.centerIn: parent
 
             Grid {
                 id: grid


### PR DESCRIPTION
The grid would become stretched when shown on a non-square or non-round display.
The score boxes would also move to non symmetrical positions.
Fix this issue by always taking the shortest length of the display and using this to draw the score boxes and the grid.

| Before | After |
|---------|---------|
| ![Screenshot_20220511_230921](https://user-images.githubusercontent.com/7857908/167950177-7dd95a7f-6f04-4f3f-bff5-23a2c21274c9.jpg) | ![Screenshot_20220511_230815](https://user-images.githubusercontent.com/7857908/167950173-094935c8-3a59-4f34-b5f8-0ca8bcc54f75.jpg) |
