### PR TITLE
GameOver: Fill screen on flat tire displays.

### DIFF
--- a/src/Game.qml
+++ b/src/Game.qml
@@ -561,7 +561,8 @@ Item {
 
     Rectangle {
         id: gameOver
-        anchors.fill: parent
+        height: Dims.h(100)
+        width: Dims.w(100)
         radius: DeviceInfo.hasRoundScreen ? width/2 : 0
         visible: false
         opacity: visible ? 0.8 : 0.0


### PR DESCRIPTION
Flat tire displays are handled by Dims in that the height also contains the flat tire height such that apps can compensate for the display cutout.

This issue was reported by @dodoradio. Thank you!

Here is the before and after:

| Before | After |
|     -        |      -    |
| ![aos-diamonds-ft](https://user-images.githubusercontent.com/7857908/218587533-746ef427-dd17-416d-9f98-921351d468ba.jpg) | ![aos-diamonds-ft-2](https://user-images.githubusercontent.com/7857908/218587546-c7ee7ac5-325a-467d-8959-9a12abb420b6.jpg) |