### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,13 @@ include(AsteroidTranslations)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-diamonds.in
+	${CMAKE_BINARY_DIR}/asteroid-diamonds
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-diamonds
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-diamonds)
 

--- a/asteroid-diamonds.desktop.template
+++ b/asteroid-diamonds.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-diamonds
+Exec=asteroid-diamonds
 Icon=2048
 X-Asteroid-Center-Color=#009933
 X-Asteroid-Outer-Color=#000C00

--- a/asteroid-diamonds.in
+++ b/asteroid-diamonds.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-diamonds.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-diamonds main.cpp resources.qrc)
-set_target_properties(asteroid-diamonds PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-diamonds PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-diamonds PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-diamonds
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIRDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker