### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/Game.qml
+++ b/src/Game.qml
@@ -564,7 +564,7 @@ Item {
         id: gameOver
         height: Dims.h(100)
         width: Dims.w(100)
-        radius: DeviceInfo.hasRoundScreen ? width/2 : 0
+        radius: DeviceSpecs.hasRoundScreen ? width/2 : 0
         visible: false
         opacity: visible ? 0.8 : 0.0
         scale: visible ? 1 : 0


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56