### PR TITLE
Fix Qt6 signal parameter injection deprecation in Game.qml

### DIFF
--- a/src/Game.qml
+++ b/src/Game.qml
@@ -495,7 +495,7 @@ Item {
             property int deltaX: 0
             property int deltaY: 0
 
-            onPressed: {
+            onPressed: (mouse) => {
                 gesture = ""
                 value = 0
                 initialX = 0
@@ -506,7 +506,7 @@ Item {
                 initialY = mouse.y
             }
 
-            onPositionChanged: {
+            onPositionChanged: (mouse) => {
                 deltaX = mouse.x - initialX
                 deltaY = mouse.y - initialY
                 horizontal = Math.abs(deltaX) > Math.abs(deltaY)


### PR DESCRIPTION
Qt6 deprecated implicit injection of signal parameters into handler bodies. `onPressed` and `onPositionChanged` in the gesture-handling MouseArea both use the `mouse` parameter but were not declaring it explicitly, producing deprecation warnings on every touch event during gameplay.

### Changes

`src/Game.qml`: convert `onPressed` and `onPositionChanged` to arrow function syntax with explicit `mouse` parameter declaration. `onReleased` does not reference the `mouse` parameter and requires no change.

### Testing

Built and deployed on sparrow. Played a full session with no `Parameter mouse is not declared` warnings in journald. Game input and gesture handling behave correctly.