### PR TITLE
Build-time QML pre-compilation via asteroid_app_qml_module

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,10 @@
-add_library(asteroid-diamonds main.cpp resources.qrc)
+add_library(asteroid-diamonds main.cpp)
 set_target_properties(asteroid-diamonds PROPERTIES PREFIX "")
+
+asteroid_app_qml_module(asteroid-diamonds
+	main.qml
+	Game.qml
+)
 
 target_link_libraries(
 	asteroid-diamonds

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,6 +1,0 @@
-<RCC>
-    <qresource prefix="/">
-        <file>main.qml</file>
-        <file>Game.qml</file>
-    </qresource>
-</RCC>


### PR DESCRIPTION
The .so ships pre-compiled QML bytecode and the engine skips the parse/JIT pipeline on every launch.